### PR TITLE
Always clear the term cache, even when not counting

### DIFF
--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -134,6 +134,8 @@ class LTCU_Plugin {
 			// `get_post_status()` above because that checks the parent status
 			// if the status is inherit.
 			$this->quick_update_terms_count( $object_id, $tt_ids, $taxonomy, $transition_type );
+		} else {
+			clean_term_cache( $tt_ids, $taxonomy, false );
 		}
 	}
 

--- a/tests/test-term-counting.php
+++ b/tests/test-term-counting.php
@@ -439,9 +439,8 @@ class TermCountingTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the first draft of a post gets terms set properly. This is
-	 * primarily aimed at external object caches, because the cache only gets
-	 * cleared when terms get set after they're counted.
+	 * Test that the first draft of a post gets terms set properly and the term
+	 * cache is cleared.
 	 *
 	 * {@see https://github.com/Automattic/lightweight-term-count-update/pull/8}
 	 */

--- a/tests/test-term-counting.php
+++ b/tests/test-term-counting.php
@@ -437,4 +437,36 @@ class TermCountingTest extends WP_UnitTestCase {
 		$this->assertEquals( sort( $GLOBALS['ltcu_fired_action_tt_ids'] ) , sort( $tt_ids ) );
 		$this->assertEquals( 'category', $GLOBALS['ltcu_fired_action_taxonomy'] );
 	}
+
+	/**
+	 * Test that the first draft of a post gets terms set properly. This is
+	 * primarily aimed at external object caches, because the cache only gets
+	 * cleared when terms get set after they're counted.
+	 *
+	 * {@see https://github.com/Automattic/lightweight-term-count-update/pull/8}
+	 */
+	function test_first_draft_save() {
+		// Create Test Category.
+		$testcat = $this->make_category();
+
+		// Create the blank post object to mimic the "Write" screen.
+		$post = get_default_post_to_edit( 'post', true );
+		$post_id = $post->ID;
+
+		// Save a draft of the post.
+		wp_update_post( array(
+			'ID' => $post_id,
+			'post_status' => 'draft',
+			'post_title' => 'some-post',
+			'post_type' => 'post',
+			'post_content' => 'some_content',
+			'post_category' => array( $testcat->term_id ),
+		) );
+
+		// Ensure that caches were cleared.
+		$terms = get_the_terms( $post_id, 'category' );
+
+		$this->assertTrue( is_array( $terms ) );
+		$this->assertSame( array( $testcat->term_id ), wp_list_pluck( $terms, 'term_id' ) );
+	}
 }


### PR DESCRIPTION
When terms are added or removed from a post, the term cache is cleared after the terms are counted. When using an external object cache, this is especially important, because the cache is persistent.

This patch fixes a bug whereby creating a new post, setting terms to it, and saving the post as a draft would lead to a stale term cache making it look like the post didn't have any terms (until the end of the request if not using an external object cache or indefinitely if using an external object cache).

[Relevant Trac ticket for core](https://core.trac.wordpress.org/ticket/40306).