### PR TITLE
Added if statement to take care of an edge condition in LTCU_Plugin->quick_update_terms_count

### DIFF
--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -229,31 +229,35 @@ class LTCU_Plugin {
 				// Ensure that these terms haven't already been counted.
 				$tt_ids = array_diff( $tt_ids, $this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] );
 
-				if ( ! empty( $tt_ids ) ) {
-					$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] = array_merge(
-						$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ],
-						$tt_ids
-					);
-					$tt_ids_string = '(' . implode( ',', $tt_ids ) . ')';
-
-					if ( 'increment' === $transition_type ) {
-						// Incrementing.
-						$update_query = "UPDATE {$wpdb->term_taxonomy} AS tt SET tt.count = tt.count + 1 WHERE tt.term_taxonomy_id IN $tt_ids_string";
-					} else {
-						// Decrementing.
-						$update_query = "UPDATE {$wpdb->term_taxonomy} AS tt SET tt.count = tt.count - 1 WHERE tt.term_taxonomy_id IN $tt_ids_string AND tt.count > 0";
-					}
-
-					foreach ( $tt_ids as $tt_id ) {
-						/** This action is documented in wp-includes/taxonomy.php */
-						do_action( 'edit_term_taxonomy', $tt_id, $taxonomy );
-					}
-					$wpdb->query( $update_query ); // WPCS: unprepared SQL ok.
-					foreach ( $tt_ids as $tt_id ) {
-						/** This action is documented in wp-includes/taxonomy.php */
-						do_action( 'edited_term_taxonomy', $tt_id, $taxonomy );
-					}
+				if ( empty( $tt_ids ) ) {
+					//No term to process. So return.
+					return;
 				}
+				
+				$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] = array_merge(
+					$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ],
+					$tt_ids
+				);
+				$tt_ids_string = '(' . implode( ',', $tt_ids ) . ')';
+
+				if ( 'increment' === $transition_type ) {
+					// Incrementing.
+					$update_query = "UPDATE {$wpdb->term_taxonomy} AS tt SET tt.count = tt.count + 1 WHERE tt.term_taxonomy_id IN $tt_ids_string";
+				} else {
+					// Decrementing.
+					$update_query = "UPDATE {$wpdb->term_taxonomy} AS tt SET tt.count = tt.count - 1 WHERE tt.term_taxonomy_id IN $tt_ids_string AND tt.count > 0";
+				}
+
+				foreach ( $tt_ids as $tt_id ) {
+					/** This action is documented in wp-includes/taxonomy.php */
+					do_action( 'edit_term_taxonomy', $tt_id, $taxonomy );
+				}
+				$wpdb->query( $update_query ); // WPCS: unprepared SQL ok.
+				foreach ( $tt_ids as $tt_id ) {
+					/** This action is documented in wp-includes/taxonomy.php */
+					do_action( 'edited_term_taxonomy', $tt_id, $taxonomy );
+				}
+
 			} // End if().
 
 			clean_term_cache( $tt_ids, $taxonomy, false );

--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -9,7 +9,7 @@
  * Domain Path:     /languages
  * Version:         0.1.0
  *
- * @package 		Lightweight_Term_Count_Update
+ * @package         Lightweight_Term_Count_Update
  */
 
 /**
@@ -57,7 +57,7 @@ class LTCU_Plugin {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new static;
+			self::$instance = new static();
 			self::$instance->setup();
 		}
 		return self::$instance;
@@ -230,10 +230,10 @@ class LTCU_Plugin {
 				$tt_ids = array_diff( $tt_ids, $this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] );
 
 				if ( empty( $tt_ids ) ) {
-					//No term to process. So return.
+					// No term to process. So return.
 					return;
 				}
-				
+
 				$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] = array_merge(
 					$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ],
 					$tt_ids
@@ -257,7 +257,6 @@ class LTCU_Plugin {
 					/** This action is documented in wp-includes/taxonomy.php */
 					do_action( 'edited_term_taxonomy', $tt_id, $taxonomy );
 				}
-
 			} // End if().
 
 			clean_term_cache( $tt_ids, $taxonomy, false );

--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -83,9 +83,9 @@ class LTCU_Plugin {
 		add_action( 'added_term_relationship', array( $this, 'added_term_relationship' ), 10, 3 );
 		add_action( 'deleted_term_relationships', array( $this, 'deleted_term_relationships' ), 10, 3 );
 
-		 /**
-		  * Possibly recount posts for a term once it's been edited.
-		  */
+		/**
+		 * Possibly recount posts for a term once it's been edited.
+		 */
 		add_action( 'edit_term', array( $this, 'maybe_recount_posts_for_term' ), 10, 3 );
 	}
 


### PR DESCRIPTION
Problem: If the terms passed to the function LTCU_Plugin->quick_update_terms_count is already processed it gives an empty array to the cache purging function which processes all the terms. This is both time intensive and not the required behavior.

How the fix works: I added code to return when the passed terms are already processed. So that the cache purging function is never invoked if there are no terms to process.