### PR TITLE
Fixes #14 Taxonomy Callback Issue

### DIFF
--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -220,7 +220,7 @@ class LTCU_Plugin {
 
 			// Respect if a taxonomy has a callback override.
 			if ( ! empty( $tax_obj->update_count_callback ) ) {
-				call_user_func( $tax_obj->update_count_callback, $tt_ids, $tax_obj->name );
+				call_user_func( $tax_obj->update_count_callback, $tt_ids, $tax_obj );
 			} elseif ( ! empty( $tt_ids ) ) {
 				if ( ! isset( $this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] ) ) {
 					$this->counted_terms[ $object_id ][ $taxonomy ][ $transition_type ] = array();


### PR DESCRIPTION
This fixes issue https://github.com/Automattic/lightweight-term-count-update/issues/14 - Taxonomy callback should pass entire taxonomy object, not just the name.

This patch has been discussed with @brettshumaker via a VIP ticket, and this will help unblock some of our work with woocommerce integrations, where we are experiencing issues (See the [issue description](https://github.com/Automattic/lightweight-term-count-update/issues/14) for more details